### PR TITLE
Adding pyattck to list of resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
 - [PoshC2](https://github.com/nettitude/PoshC2_Python) - PoshC2 is a proxy aware C2 framework that utilises Powershell and/or equivalent (System.Management.Automation.dll) to aid penetration testers with red teaming, post-exploitation and lateral movement. 
 - [Empire](https://github.com/EmpireProject/Empire) - Post-exploitation framework that includes a pure-PowerShell2.0 Windows agent, and a pure Python 2.6/2.7 Linux/OS X agent.
 - [PowerSploit](https://github.com/PowerShellMafia/PowerSploit/) - Collection of Microsoft PowerShell modules that can be used to aid penetration testers during all phases of an assessment.
-- [Invoke-PSImage](https://github.com/peewpw/Invoke-PSImage) - Invoke-PSImage takes a PowerShell script and embeds the bytes of the script into the pixels of a PNG image. 
+- [Invoke-PSImage](https://github.com/peewpw/Invoke-PSImage) - Invoke-PSImage takes a PowerShell script and embeds the bytes of the script into the pixels of a PNG image.
 
 #### Purple Team
 - [RE:TERNAL](https://github.com/d3vzer0/reternal-quickstart) - RE:TERNAL is a centralised purple team simulation platform. Reternal uses agents installed on a simulation network to execute various known red-teaming techniques in order to test blue-teaming capabilities.
@@ -93,6 +93,7 @@
 - [atomic-threat-coverage](https://github.com/krakow2600/atomic-threat-coverage) - Automatically generated actionable analytics designed to combat threats based on MITRE's ATT&CK.
 - [CyberMenace](https://github.com/PM0ney/CyberMenace) - A one stop shop hunting app in Splunk that can ingest Zeek, Suricata, Sysmon, and Windows event data to find malicious indicators of compromise relating to the MITRE ATT&CK Matrix.
 - [Wayfinder](https://github.com/egaus/wayfinder) - Artificial Intelligence Agent to extract threat intelligence TTPs from feeds of malicious and benign event sources and automate threat hunting activities.
+- [pyattck](https://github.com/swimlane/pyattck) - A python package to interact with the Mitre ATT&CK Framework. You can find documentation [here](https://pyattck.readthedocs.io/en/latest/)
 
 ------
 


### PR DESCRIPTION
I released a new Python package called `pyattck`.  This package enables you to retrieve data from the Mitre ATT&CK Framework, as well as relationship data points (e.g. Actors -> Their Tools, Malware, & Techniques).  

Here is some sample code on how to use `pyattck`:

```python
from pyattck import Attck

attack = Attck()

# accessing actors
for actor in attack.actors:
    print(actor)

    # accessing malware used by an actor or group
    for malware in actor.malware:
        print(malware)

    # accessing tools used by an actor or group
    for tool in actor.tools:
        print(tool)

    # accessing techniques used by an actor or group
    for technique in actor.techniques:
        print(technique)

# accessing malware
for malware in attack.malwares:
    print(malware)

    # accessing actor or groups using this malware
    for actor in malware.actors:
        print(actor)

    # accessing techniques that this malware is used in
    for technique in malware.techniques:
        print(technique)

# accessing mitigation
for mitigation in attack.mitigations:
    print(mit)

    # accessing techniques related to mitigation recommendations
    for technique in mitigation.techniques:
        print(technique)

# accessing tactics
for tactic in attack.tactics:
    print(tactic)

    # accessing techniques related to this tactic
    for technique in tactic.techniques:
        print(technique)

# accessing techniques
for technique in attack.techniques:
    print(technique)

    # accessing tactics that this technique belongs to
    for tactic in technique.tactics:
        print(tactic)

    # accessing mitigation recommendations for this technique
    for mitigation in technique.mitigation:
        print(mitigation)

    # accessing actors using this technique
    for actor in technique.actors:
        print(actor)


# accessing tools
for tool in attack.tools:
    print(tool)

    # accessing techniques this tool is used in
    for technique in tool.techniques:
        print(technique)

    # accessing actor or groups using this tool
    for actor in tool.actors:
        print(actor)
```

Check it out and let me know what you think!

Blog: [https://swimlane.com/blog/swimlane-research-team-open-sources-pyattack/](https://swimlane.com/blog/swimlane-research-team-open-sources-pyattack/)

Docs: [https://pyattck.readthedocs.io/en/latest/](https://pyattck.readthedocs.io/en/latest/)

Repo: [https://github.com/swimlane/pyattck](https://github.com/swimlane/pyattck)